### PR TITLE
Ignore "required" field on grouped parameters

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -192,7 +192,15 @@ module Grape
 
                 dataType    = value.is_a?(Hash) ? (value[:type] || 'String').to_s : 'String'
                 description = value.is_a?(Hash) ? value[:desc] || value[:description] : ''
-                required    = value.is_a?(Hash) ? !!value[:required] : false
+
+                # If the parameter is part of a group, ignore the 'required' field. We have no way to process
+                # Grape parameter groups properly, since they're not part of the Swagger spec.
+                required = if value.is_a?(Hash) && !param_is_part_of_group?(param)
+                  !!value[:required]
+                else
+                  false
+                end
+
                 defaultValue = value.is_a?(Hash) ? value[:defaultValue] : nil
                 paramType = if path.include?(":#{param}")
                    'path'
@@ -226,6 +234,10 @@ module Grape
               end
 
               content_types.uniq
+            end
+
+            def param_is_part_of_group?(param)
+              param =~ /^.+\[.+\]$/
             end
 
             def parse_info(info)

--- a/spec/form_params_spec.rb
+++ b/spec/form_params_spec.rb
@@ -24,6 +24,10 @@ describe "Form Params" do
       params do
         requires :id, type: Integer, desc: "id of item"
         requires :name, type: String, desc: "name of item"
+        group :media do
+          requires :url, type: String, desc: "url of item"
+          optional :image_url, type: String, desc: "image url of item"
+        end
       end
       patch '/items/:id' do
         {}
@@ -73,7 +77,7 @@ describe "Form Params" do
               "summary" => "",
               "nickname" => "PATCH-items--id---format-",
               "httpMethod" => "PATCH",
-              "parameters" => [ { "paramType" => "path", "name" => "id", "description" => "id of item", "type" => "Integer", "dataType" => "Integer", "required" => true }, { "paramType" => "form", "name" => "name", "description" => "name of item", "type" => "String", "dataType" => "String", "required" => true } ]
+              "parameters" => [ { "paramType" => "path", "name" => "id", "description" => "id of item", "type" => "Integer", "dataType" => "Integer", "required" => true }, { "paramType" => "form", "name" => "name", "description" => "name of item", "type" => "String", "dataType" => "String", "required" => true }, { "paramType" => "form", "name" => "media[url]", "description" => "url of item", "type" => "String", "dataType" => "String", "required" => false }, { "paramType" => "form", "name" => "media[image_url]", "description" => "image url of item", "type" => "String", "dataType" => "String", "required" => false } ]
             }
           ]
         }


### PR DESCRIPTION
The [Swagger spec](https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#52-api-declaration) doesn't have any support for grouped parameters. They're a [Grape thing](https://github.com/intridea/grape#parameter-validation-and-coercion).

Currently `grape-swagger` is ignoring the description of parameter groups, and just trusting the `requires` or `optional` state of the contained leaf parameters. This leads to trouble when using something like [swagger-ui](https://github.com/wordnik/swagger-ui) for documentation and sandboxing, as it may require a user to enter certain parameters that shouldn't actually be required.

The hacky fix here is to ignore the `required` bit on parameters that are part of a group. It doesn't really fix the problem, it lessens the impact. (Note that Grape will still throw an error if a truly-required parameter isn't specified, so this change just affects the documentation / sandbox client.)
