### PR TITLE
Add ability to hide attributes in entity descriptions

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -303,6 +303,8 @@ module Grape
                 properties  = {}
 
                 model.documentation.each do |property_name, property_info|
+                  next if property_info[:hidden]
+
                   properties[property_name] = property_info
 
                   # rename Grape Entity's "desc" to "description"

--- a/spec/hide_entity_attribute_spec.rb
+++ b/spec/hide_entity_attribute_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe "an API with hidden entity attributes" do
+  before :all do
+    module Entities
+      class Item < Grape::Entity
+        expose :id, documentation: { type: 'string', desc: 'The item ID' }
+        expose :secret_name, documentation: { type: 'string', hidden: true, desc: 'A super secret name of the item' }
+      end
+    end
+
+    class HideEntityAttributeApi < Grape::API
+
+      desc 'Add an item', {
+        entity: Entities::Item
+      }
+      post '/items' do
+        {}
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  def app; HideEntityAttributeApi end
+
+  it "retrieves swagger-documentation that doesn't include hidden attributes in entities" do
+    get '/swagger_doc/items.json'
+    JSON.parse(last_response.body).should ==  {
+      "apiVersion" => "0.1",
+      "swaggerVersion" => "1.2",
+      "resourcePath" => "",
+      "apis" => [{
+        "path" => "/items.{format}",
+        "operations" => [{
+          "produces" => ["application/xml","application/json","text/plain"],
+          "notes" => "",
+          "summary" => "Add an item",
+          "nickname" => "POST-items---format-",
+          "httpMethod" => "POST",
+          "parameters" => [],
+          "type" => "Item"
+        }]
+      }],
+      "basePath" => "http://example.org",
+      "models" => {
+        "Item" => {
+          "id" => "Item",
+          "name" => "Item",
+          "properties" => {
+            "id" => {
+              "type" => "string",
+              "description" => "The item ID"
+            }
+          }
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
This will be useful for some upcoming feature work where we don't want to expose certain attributes in our swagger documentation until we're ready to launch.
