### PR TITLE
support grape 0.16.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem 'grape', '~> 0.11.0'
+gem 'grape', '~> 0.16.0'
 gem 'grape-entity', '>= 0.3.0'
 gem 'kramdown', '>= 1.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,18 +16,19 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.1.3)
+    enumerable-lazy (0.0.2)
     equalizer (0.0.11)
     ffi (1.9.14-java)
     git (1.2.5)
-    grape (0.11.0)
+    grape (0.16.2)
       activesupport
       builder
       hashie (>= 2.1.0)
       multi_json (>= 1.3.2)
       multi_xml (>= 0.5.2)
+      mustermann19 (~> 0.4.3)
       rack (>= 1.3.0)
       rack-accept
-      rack-mount
       virtus (>= 1.0.0)
     grape-entity (0.3.0)
       activesupport
@@ -46,6 +47,8 @@ GEM
     method_source (0.8.2)
     multi_json (1.7.7)
     multi_xml (0.5.5)
+    mustermann19 (0.4.4)
+      enumerable-lazy
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -61,8 +64,6 @@ GEM
     rack (1.5.2)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-mount (0.8.3)
-      rack (>= 1.0.0)
     rack-test (0.6.1)
       rack (>= 1.0)
     rake (0.9.2.2)
@@ -99,7 +100,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (> 1.0.0)
-  grape (~> 0.11.0)
+  grape (~> 0.16.0)
   grape-entity (>= 0.3.0)
   jeweler (~> 1.8.4)
   kramdown (>= 1.3.1)


### PR DESCRIPTION
stop using deprecated route APIs. fixes these warnings

```
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/sumeet/remind/grape-swagger/lib/grape-swagger.rb:20: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
```